### PR TITLE
add the curl functionality

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,17 +7,23 @@ import (
 	"net/http"
 
 	Telnet "telnetapp/pkg/backend"
+	"telnetapp/pkg/curl" 
 )
 
 func main() {
 
-	fs := http.FileServer(http.Dir("./static"))
-	http.Handle("/", fs)
-	http.HandleFunc("/telnet", handleTelnet)
+    fs := http.FileServer(http.Dir("./static"))
+    http.Handle("/", fs)
+    http.HandleFunc("/telnet", handleTelnet)
+    http.HandleFunc("/curl", handleCurl)
 
-	fmt.Printf("Server starting on port 8080... \n")
-	http.ListenAndServe(":8080", nil)
+    fmt.Printf("Server starting on port 8080... \n")
+    http.ListenAndServe(":8080", nil)
 
+}
+
+func handleCurl(w http.ResponseWriter, r *http.Request) {
+    curl.HandleCurl(w, r)
 }
 
 func handleTelnet(w http.ResponseWriter, r *http.Request) {

--- a/pkg/curl/curl.go
+++ b/pkg/curl/curl.go
@@ -1,0 +1,39 @@
+package curl
+
+import (
+	"encoding/json"
+	"net/http"
+	"os/exec"
+)
+
+type CurlRequest struct {
+	Command string `json:"command"`
+}
+
+type CurlResponse struct {
+	Output  string `json:"content"`
+	Error   string `json:"error,omitempty"`
+	Success bool   `json:"success"`
+}
+
+func HandleCurl(w http.ResponseWriter, r *http.Request) {
+    var req CurlRequest
+    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+        http.Error(w, "Invalid request body", http.StatusBadRequest)
+        return
+    }
+
+    cmd := exec.Command("sh", "-c", req.Command)
+    output, err := cmd.CombinedOutput()
+
+    response := CurlResponse{
+        Output:  string(output),
+        Success: err == nil,
+    }
+    if err != nil {
+        response.Error = err.Error()
+    }
+
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(response)
+}


### PR DESCRIPTION
This pull request introduces a new feature that adds support for handling `curl` commands through the web server. The changes include adding a new handler for `curl` commands and defining the necessary structures and logic to process these commands.

### New Feature: Curl Command Handling

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R10-R28): Added a new import for `telnetapp/pkg/curl` and registered a new route `/curl` to handle `curl` commands via the `handleCurl` function.
* [`pkg/curl/curl.go`](diffhunk://#diff-33789393a4d29e25126a2b857d2c15e53a71f1c488c46d88dd007ace41c05855R1-R39): Created a new package `curl` with the `HandleCurl` function to process incoming `curl` command requests. This includes defining `CurlRequest` and `CurlResponse` types, decoding the request body, executing the `curl` command, and returning the output as JSON.